### PR TITLE
Docs: add missing docstrings, fix inaccurate docstrings/typos, remove dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 **Huawei Noah's Ark Lab**
 
-<p>Main repository for the CVPR 2020 paper <b>DeepLPF: Deep Local Parametric Filters for Image Enhancement</b>. Here you will find a link to the code, pre-trained models and information on the datasets. Please raise a Github issue if you need assistance of have any questions on the research. 
+<p>Main repository for the CVPR 2020 paper <b>DeepLPF: Deep Local Parametric Filters for Image Enhancement</b>. Here you will find a link to the code, pre-trained models and information on the datasets. Please raise a Github issue if you need assistance or have any questions on the research. 
 </p>
 
-**_Training your own DeepLPF:_** if you have difficulities, please contact the lead author for assistance. We are responsive and will be glad to assist on any queries regarding the model.
+**_Training your own DeepLPF:_** if you have difficulties, please contact the lead author for assistance. We are responsive and will be glad to assist on any queries regarding the model.
 
-**_BATCH SIZE: Note this code is designed for a batch size of 1. It needs re-engineered to support higher batch sizes. Using higher batch sizes is not supported currently. To replicate our reported results please use a batch size of 1 only. If you do have a patch for DeepLPF to support higher batch sizes please raise a pull request on this repo and we will integrate._**
+**_BATCH SIZE: Note this code is designed for a batch size of 1. It needs to be re-engineered to support higher batch sizes. Using higher batch sizes is not supported currently. To replicate our reported results please use a batch size of 1 only. If you do have a patch for DeepLPF to support higher batch sizes please raise a pull request on this repo and we will integrate._**
 
 <p align="center">
 <img src="./images/teaser.png" width="80%"/>

--- a/data.py
+++ b/data.py
@@ -33,6 +33,13 @@ np.set_printoptions(threshold=sys.maxsize)
 
 
 class Dataset(torch.utils.data.Dataset):
+    """PyTorch dataset of (input, target) image pairs with lazy loading.
+
+    Wraps a dictionary of image-pair filepaths and loads each pair from disk on
+    demand. During training (``is_valid=False``) it applies random horizontal
+    and vertical flips as data augmentation; validation, test and inference
+    modes load the images unaugmented.
+    """
 
     def __init__(self, data_dict, transform=None, normaliser=2 ** 8 - 1, is_valid=False, is_inference=False):
         """Initialisation for the Dataset object
@@ -127,6 +134,11 @@ class Dataset(torch.utils.data.Dataset):
 
 
 class DataLoader():
+    """Abstract base class for dataset-specific loaders.
+
+    Subclasses implement :meth:`load_data` to scan a directory and build the
+    dictionary of image-pair filepaths consumed by :class:`Dataset`.
+    """
 
     def __init__(self, data_dirpath, img_ids_filepath):
         """Initialisation function for the data loader
@@ -162,6 +174,12 @@ class DataLoader():
 
 
 class Adobe5kDataLoader(DataLoader):
+    """Data loader for the Adobe5k image-enhancement dataset.
+
+    Walks ``data_dirpath`` for images whose id (the filename prefix before the
+    first ``-``) appears in ``img_ids_filepath``, pairing each ``input`` image
+    with its corresponding ``output`` image.
+    """
 
     def __init__(self, data_dirpath, img_ids_filepath):
         """Initialisation function for the data loader
@@ -176,7 +194,7 @@ class Adobe5kDataLoader(DataLoader):
         self.data_dict = defaultdict(dict)
 
     def load_data(self):
-        """ Loads the Samsung image data into a Python dictionary
+        """ Loads the Adobe5k image data into a Python dictionary
 
         :returns: Python two-level dictionary containing the images
         :rtype: Dictionary of dictionaries

--- a/main.py
+++ b/main.py
@@ -43,7 +43,17 @@ np.set_printoptions(threshold=sys.maxsize)
 matplotlib.use('agg')
 
 def main():
+    """Entry point for training and inference.
 
+    Parses command-line arguments and either (a) runs inference with a saved
+    checkpoint when both ``--checkpoint_filepath`` and ``--inference_img_dirpath``
+    are supplied, or (b) trains a DeepLPF model from scratch on the Adobe5k
+    dataset, periodically evaluating on the validation and test splits and
+    saving the best-PSNR checkpoint.
+
+    Note: the code only supports a batch size of 1. Remove the ``exit()`` call
+    below (kept as a guard) before running.
+    """
     print("*** Before running this code ensure you keep the default batch size of 1. The code has not been engineered to support higher batch sizes. See README for more detail. Remove the exit() statement to use code. ***")
     exit()
 
@@ -62,9 +72,9 @@ def main():
         description="Train the DeepLPF neural network on image pairs")
 
     parser.add_argument(
-        "--num_epoch", type=int, required=False, help="Number of epoches (default 5000)", default=100000)
+        "--num_epoch", type=int, required=False, help="Number of epochs (default 100000)", default=100000)
     parser.add_argument(
-        "--valid_every", type=int, required=False, help="Number of epoches after which to compute validation accuracy",
+        "--valid_every", type=int, required=False, help="Number of epochs after which to compute validation accuracy",
         default=25)
     parser.add_argument(
         "--checkpoint_filepath", required=False, help="Location of checkpoint file", default=None)

--- a/metric.py
+++ b/metric.py
@@ -32,6 +32,12 @@ np.set_printoptions(threshold=sys.maxsize)
 
 
 class Evaluator():
+    """Evaluates a trained network on a dataset split.
+
+    Runs the network over every image in a data loader, computes the loss, PSNR
+    and SSIM, and writes the first 30 enhanced images to disk (annotated with
+    their per-image PSNR/SSIM) for qualitative inspection.
+    """
 
     def __init__(self, criterion, data_loader, split_name, log_dirpath):
         """Initialisation function for the data loader

--- a/model.py
+++ b/model.py
@@ -30,12 +30,18 @@ matplotlib.use('agg')
 
 
 class DeepLPFLoss(nn.Module):
+    """DeepLPF training loss.
+
+    Combines an L1 term in CIELAB colour space with a multi-scale structural
+    similarity (MS-SSIM) term on the L (lightness) channel, as described in
+    Section 3.4 of the paper. The total loss is ``L1 + 1e-3 * (1 - MS-SSIM)``.
+    """
 
     def __init__(self, ssim_window_size=5, alpha=0.5):
         """Initialisation of the DeepLPF loss function
 
         :param ssim_window_size: size of averaging window for SSIM
-        :param alpha: interpolation paramater for L1 and SSIM parts of the loss
+        :param alpha: interpolation parameter for L1 and SSIM parts of the loss
         :returns: N/A
         :rtype: N/A
 
@@ -175,10 +181,10 @@ class DeepLPFLoss(nn.Module):
     def forward(self, predicted_img_batch, target_img_batch):
         """Forward function for the DeepLPF loss
 
-        :param predicted_img_batch: 
-        :param target_img_batch: Tensor of shape BxCxWxH
+        :param predicted_img_batch: predicted image Tensor of shape BxCxHxW
+        :param target_img_batch: ground-truth image Tensor of shape BxCxHxW
         :returns: value of loss function
-        :rtype: float
+        :rtype: Tensor
 
         """
         if predicted_img_batch.shape[2]!=target_img_batch.shape[2]:
@@ -219,6 +225,14 @@ class DeepLPFLoss(nn.Module):
 
 
 class BinaryLayer(nn.Module):
+    """Binarisation layer with a straight-through estimator.
+
+    The forward pass returns the sign of the input; the backward pass passes
+    gradients through unchanged except where the input saturates (|input| > 1),
+    following the straight-through estimator of Courbariaux et al. It is used by
+    the graduated filter to make discrete above/below-line decisions while
+    remaining trainable end-to-end.
+    """
 
     def forward(self, input):
         """Forward function for binary layer
@@ -245,13 +259,21 @@ class BinaryLayer(nn.Module):
 
 
 class CubicFilter(nn.Module):
+    """Cubic-polynomial filter branch of DeepLPF.
+
+    Regresses 60 coefficients (20 per RGB channel) from the backbone features
+    and evaluates a per-pixel cubic polynomial in the normalised (x, y) image
+    coordinates and the pixel intensity, producing an additive adjustment map.
+    See Section 3.2 of the paper.
+    """
 
     def __init__(self, num_in_channels=64, num_out_channels=64, batch_size=1):
-        """Initialisation function
+        """Build the cubic-filter branch.
 
-        :param block: a block (layer) of the neural network
-        :param num_layers:  number of neural network layers
-        :returns: initialises parameters of the neural networ
+        :param num_in_channels: number of input feature-map channels
+        :param num_out_channels: number of channels used by the conv stack
+        :param batch_size: image batch size (only 1 is supported)
+        :returns: N/A
         :rtype: N/A
 
         """
@@ -354,6 +376,13 @@ class CubicFilter(nn.Module):
 
 
 class GraduatedFilter(nn.Module):
+    """Graduated-filter branch of DeepLPF.
+
+    Emulates a photographic graduated neutral-density filter. Regresses the
+    parameters of three graduated filters per RGB channel (line slope, offset,
+    scale, and an above/below-line indicator via :class:`BinaryLayer`) and
+    combines them into a multiplicative scaling map. See Section 3.3 of the paper.
+    """
 
     def __init__(self, num_in_channels=64, num_out_channels=64):
         """Initialisation function for the graduated filter
@@ -410,7 +439,7 @@ class GraduatedFilter(nn.Module):
         :param factor: scale factor
         :param invert: binary indicator variable
         :param d1: distance between top and mid line
-        :param d2: distannce between botto and mid line
+        :param d2: distance between bottom and mid line
         :param max_scale: maximum scaling factor possible
         :param top_line:  representation of top line
         :returns: inverted scaling mask
@@ -506,7 +535,6 @@ class GraduatedFilter(nn.Module):
 
         # Scales
         max_scale = 2
-        min_scale = 0
 
         scale_factor1 = self.tanh01(G[0, 15]) * max_scale
         scale_factor2 = self.tanh01(G[0, 16]) * max_scale
@@ -579,13 +607,20 @@ class GraduatedFilter(nn.Module):
 
 
 class EllipticalFilter(nn.Module):
+    """Elliptical-filter branch of DeepLPF.
+
+    Regresses the parameters of three rotated ellipses per RGB channel (centre,
+    semi-axes, orientation and scale) from the backbone features and produces a
+    multiplicative scaling map whose effect decays with radius inside each
+    ellipse. See Section 3.3 of the paper.
+    """
 
     def __init__(self, num_in_channels=64, num_out_channels=64):
-        """Initialisation function
+        """Build the elliptical-filter branch.
 
-        :param block: a block (layer) of the neural network
-        :param num_layers:  number of neural network layers
-        :returns: initialises parameters of the neural networ
+        :param num_in_channels: number of input feature-map channels
+        :param num_out_channels: number of channels used by the conv stack
+        :returns: N/A
         :rtype: N/A
 
         """
@@ -633,11 +668,22 @@ class EllipticalFilter(nn.Module):
         """Gets the elliptical scaling mask according to the equation of a
         rotated ellipse
 
+        :param x_axis: normalised x-coordinate grid
+        :param y_axis: normalised y-coordinate grid
+        :param shift_x: ellipse centre x-coordinate
+        :param shift_y: ellipse centre y-coordinate
+        :param semi_axis_x: ellipse semi-axis along x
+        :param semi_axis_y: ellipse semi-axis along y
+        :param alpha: rotation angle of the ellipse
+        :param scale_factor: peak scaling applied at the ellipse centre
+        :param max_scale: maximum permitted scaling factor
+        :param eps: small constant to avoid division by zero
+        :param radius: ellipse radius at the current angle
         :returns: scaling mask
         :rtype: Tensor
 
         """
-        # Check whether a point is inside our outside of the ellipse and set the scaling factor accordingly
+        # Check whether a point is inside or outside of the ellipse and set the scaling factor accordingly
         ellipse_equation_part1 = (((x_axis - shift_x)*torch.cos(alpha) + (y_axis - shift_y)*torch.sin(alpha)) ** 2) / ((semi_axis_x)**2)
         ellipse_equation_part2 = (((x_axis - shift_x)*torch.sin(alpha) - (y_axis - shift_y)*torch.cos(alpha)) ** 2) / ((semi_axis_y)**2)
 
@@ -666,7 +712,6 @@ class EllipticalFilter(nn.Module):
 
         # max_scale is the maximum an ellipse can scale the image R,G,B values by
         max_scale = 2
-        min_scale = 0
 
         feat_elliptical = torch.cat((feat, img), 1)
         feat_elliptical = self.upsample(feat_elliptical)
@@ -693,21 +738,13 @@ class EllipticalFilter(nn.Module):
         y_axis = Variable(torch.arange(img.shape[3]).repeat(
             img.shape[2], 1).cuda()) / img.shape[3]
 
-        # x coordinate - h position
-        right_x = (img.shape[2] - 1) / img.shape[2]
-        left_x = 0
-
         # Centre of ellipse, x-coordinate
         x_coord1 = self.tanh01(G[0, 0]) + eps1
         x_coord2 = self.tanh01(G[0, 1]) + eps1
         x_coord3 = self.tanh01(G[0, 2]) + eps1
 
-        # y coordinate - k coordinate
-        right_y = (img.shape[3] - 1) // img.shape[3]
-        left_y = 0
-
         # Centre of ellipse, y-coordinate
-        y_coord1 = self.tanh01(G[0, 3]) + eps1 
+        y_coord1 = self.tanh01(G[0, 3]) + eps1
         y_coord2 = self.tanh01(G[0, 4]) + eps1
         y_coord3 = self.tanh01(G[0, 5]) + eps1
 
@@ -819,6 +856,7 @@ class EllipticalFilter(nn.Module):
 
 
 class Block(nn.Module):
+    """Base class providing shared convolution helpers for the conv blocks."""
 
     def __init__(self):
         """Initialisation for a lower-level DeepLPF conv block
@@ -844,16 +882,16 @@ class Block(nn.Module):
 
 
 class ConvBlock(Block, nn.Module):
+    """3x3 strided convolution followed by a LeakyReLU non-linearity."""
 
     def __init__(self, num_in_channels, num_out_channels, stride=1):
         """Initialise function for the higher level convolution block
 
-        :param in_channels:
-        :param out_channels:
-        :param stride:
-        :param padding:
-        :returns:
-        :rtype:
+        :param num_in_channels: number of input channels
+        :param num_out_channels: number of output channels
+        :param stride: unused; the internal convolution uses a fixed stride of 2
+        :returns: N/A
+        :rtype: N/A
 
         """
         super(Block, self).__init__()
@@ -873,6 +911,7 @@ class ConvBlock(Block, nn.Module):
 
 
 class MaxPoolBlock(Block, nn.Module):
+    """2x2 max-pooling block with stride 2 (halves the spatial resolution)."""
 
     def __init__(self):
         """Initialise function for the max pooling block
@@ -898,10 +937,12 @@ class MaxPoolBlock(Block, nn.Module):
 
 
 class GlobalPoolingBlock(Block, nn.Module):
+    """Global average-pooling block collapsing each feature map to a scalar."""
 
     def __init__(self, receptive_field):
         """Implementation of the global pooling block. Takes the average over a 2D receptive field.
-        :param receptive_field:
+        :param receptive_field: nominal receptive field size (unused; an
+            adaptive average pool to a 1x1 output is used instead)
         :returns: N/A
         :rtype: N/A
 
@@ -922,7 +963,14 @@ class GlobalPoolingBlock(Block, nn.Module):
 
 
 class DeepLPFParameterPrediction(nn.Module):
-    import torch.nn.functional as F
+    """Applies the three parametric filters and fuses them into an enhanced image.
+
+    Given the backbone feature maps (with the input RGB image concatenated in
+    the first three channels), this module runs the cubic, graduated and
+    elliptical filter branches and combines their outputs to produce the final
+    enhanced image. This is the "Deep Local Parametric Filters" head of the
+    network.
+    """
 
     def __init__(self, num_in_channels=64, num_out_channels=64, batch_size=1):
         """Initialisation function
@@ -957,7 +1005,6 @@ class DeepLPFParameterPrediction(nn.Module):
         img = x[:, 0:3, :, :]
 
         torch.cuda.empty_cache()
-        shape = x.shape
 
         img_cubic = self.cubic_filter.get_cubic_mask(feat, img)
        
@@ -977,11 +1024,17 @@ class DeepLPFParameterPrediction(nn.Module):
 
 
 class DeepLPFNet(nn.Module):
+    """End-to-end DeepLPF network.
+
+    Composes the U-Net backbone (:class:`unet.UNetModel`) with the parametric
+    filter head (:class:`DeepLPFParameterPrediction`) to map an input RGB image
+    to an enhanced RGB image.
+    """
 
     def __init__(self):
         """Initialisation function
 
-        :returns: initialises parameters of the neural networ
+        :returns: initialises the parameters of the neural network
         :rtype: N/A
 
         """
@@ -992,9 +1045,9 @@ class DeepLPFNet(nn.Module):
     def forward(self, img):
         """Neural network forward function
 
-        :param img: forward the data img through the network
-        :returns: residual image
-        :rtype: numpy ndarray
+        :param img: input RGB image Tensor of shape BxCxHxW
+        :returns: enhanced RGB image Tensor of shape BxCxHxW
+        :rtype: Tensor
 
         """
         feat = self.backbonenet(img)

--- a/unet.py
+++ b/unet.py
@@ -20,9 +20,16 @@ import torch
 import torch.nn as nn
 
 class UNet(nn.Module):
+    """U-Net backbone used to extract per-pixel features from the input image.
+
+    A standard encoder-decoder U-Net with skip connections built from
+    :class:`LocalNet` double-convolution blocks. The decoder pads feature maps
+    as needed so skip connections align for arbitrary input sizes, and a global
+    residual connection adds the input image back to the output.
+    """
 
     def __init__(self):
-        """UNet implementation
+        """Build the U-Net encoder-decoder layers.
 
         :returns: N/A
         :rtype: N/A
@@ -142,6 +149,11 @@ class UNet(nn.Module):
 
 
 class LocalNet(nn.Module):
+    """Double 3x3 convolution block with reflection padding and LeakyReLU.
+
+    The basic building block of the U-Net encoder and decoder: two reflection-
+    padded 3x3 convolutions each followed by a LeakyReLU activation.
+    """
 
     def forward(self, x_in):
         """Double convolutional block
@@ -174,6 +186,12 @@ class LocalNet(nn.Module):
 
 # Model definition
 class UNetModel(nn.Module):
+    """U-Net backbone wrapper that produces a 64-channel feature map.
+
+    Runs the :class:`UNet` and projects its 3-channel output to a 64-channel
+    feature map with a final reflection-padded 3x3 convolution. This feature map
+    is what the parametric filter head consumes.
+    """
 
     def __init__(self):
         """UNet model definition
@@ -190,10 +208,10 @@ class UNetModel(nn.Module):
         self.refpad = nn.ReflectionPad2d(1)
 
     def forward(self, img):
-        """UNet model definition
+        """Extract features from the input image.
 
-        :param image: input image
-        :returns: image features
+        :param img: input RGB image Tensor of shape BxCxHxW
+        :returns: 64-channel feature map Tensor of shape Bx64xHxW
         :rtype: Tensor
 
         """

--- a/util.py
+++ b/util.py
@@ -29,14 +29,22 @@ np.set_printoptions(threshold=sys.maxsize)
 
 
 class ImageProcessing(object):
+    """Stateless image-processing helpers (colour conversion and metrics).
+
+    All methods are static; the class is used purely as a namespace. Tensor
+    methods operate on CHW image tensors, while the numpy metric helpers operate
+    on batched arrays of shape BxCxHxW.
+    """
 
     @staticmethod
     def rgb_to_lab(img, is_training=True):
         """ PyTorch implementation of RGB to LAB conversion: https://docs.opencv.org/3.3.0/de/d25/imgproc_color_conversions.html
         Based roughly on a similar implementation here: https://github.com/affinelayer/pix2pix-tensorflow/blob/master/pix2pix.py
-        :param img: 
-        :returns: 
-        :rtype: 
+
+        :param img: RGB image Tensor of shape CxHxW with values in [0, 1]
+        :param is_training: unused; retained for backward compatibility
+        :returns: CIELAB image Tensor of shape CxHxW with each channel rescaled to [0, 1]
+        :rtype: Tensor
 
         """
         img = img.permute(2, 1, 0)
@@ -108,7 +116,7 @@ class ImageProcessing(object):
 
     @staticmethod
     def swapimdims_HW3_3HW(img):
-        """Move the image channels to the last dimensiion of the numpy
+        """Move the image channels to the last dimension of the numpy
         multi-dimensional array
 
         :param img: numpy nd array representing the image
@@ -148,7 +156,7 @@ class ImageProcessing(object):
 
     @staticmethod
     def compute_mse(original, result):
-        """Computes the mean squared error between to RGB images represented as multi-dimensional numpy arrays.
+        """Computes the mean squared error between two RGB images represented as multi-dimensional numpy arrays.
 
         :param original: input RGB image as a numpy array
         :param result: target RGB image as a numpy array
@@ -162,8 +170,8 @@ class ImageProcessing(object):
     def compute_psnr(image_batchA, image_batchB, max_intensity):
         """Computes the PSNR for a batch of input and output images
 
-        :param image_batchA: numpy nd-array representing the image batch A of shape Bx3xWxH
-        :param image_batchB: numpy nd-array representing the image batch A of shape Bx3xWxH
+        :param image_batchA: numpy nd-array representing image batch A of shape Bx3xHxW
+        :param image_batchB: numpy nd-array representing image batch B of shape Bx3xHxW
         :param max_intensity: maximum intensity possible in the image (e.g. 255)
         :returns: average PSNR for the batch of images
         :rtype: float
@@ -186,10 +194,9 @@ class ImageProcessing(object):
     def compute_ssim(image_batchA, image_batchB):
         """Computes the SSIM for a batch of input and output images
 
-        :param image_batchA: numpy nd-array representing the image batch A of shape Bx3xWxH
-        :param image_batchB: numpy nd-array representing the image batch A of shape Bx3xWxH
-        :param max_intensity: maximum intensity possible in the image (e.g. 255)
-        :returns: average PSNR for the batch of images
+        :param image_batchA: numpy nd-array representing image batch A of shape Bx3xHxW
+        :param image_batchB: numpy nd-array representing image batch B of shape Bx3xHxW
+        :returns: average SSIM for the batch of images
         :rtype: float
 
         """


### PR DESCRIPTION
## Summary

A **behaviour-preserving** documentation and cleanup pass across the codebase. No numerical logic was changed — a deterministic forward pass, the DeepLPF loss, and `rgb_to_lab` all produce **bit-for-bit identical** outputs before and after (SHA-256 of the output tensors unchanged).

**Net:** +171 / −59 across 7 files.

## Documentation
- Fixed ~12 typos across docstrings/comments/README (`paramater`, `networ` ×3, `distannce`, `dimensiion`, `epoches` ×2, "inside our outside", "Samsung"→"Adobe5k", `difficulities`, "needs re-engineered", …).
- Added the **19 missing class-level docstrings**, each noting the module's role and the relevant paper section.
- Corrected several **inaccurate** docstrings:
  - `CubicFilter.__init__` / `EllipticalFilter.__init__` documented nonexistent `block` / `num_layers` params.
  - `util.ImageProcessing.compute_ssim` claimed to return PSNR.
  - `UNetModel.forward` documented `:param image:` (the argument is `img`).
  - `DeepLPFNet.forward` claimed a `numpy ndarray` return (it returns a `Tensor`).
- Documented genuinely surprising behaviour accurately (e.g. `ConvBlock`'s `stride` argument is ignored — a fixed stride of 2 is used).
- `main.py`: added a `main()` docstring and fixed the argparse help text (`epoches`→`epochs`, corrected the default-epochs note). These are display-only help strings.

## Dead-code cleanup (`model.py`)
- Removed the duplicate class-body `import torch.nn.functional as F` (the module-level import is retained and used).
- Removed unused locals: `shape = x.shape`, two `min_scale = 0`, and the unused ellipse coordinates `left_x` / `right_x` / `left_y` / `right_y`.

## How reproducibility was verified
1. Captured golden SHA-256 fingerprints of a seeded `DeepLPFNet` forward pass, the `DeepLPFLoss`, and `ImageProcessing.rgb_to_lab` on the pristine tree.
2. Re-ran the same fingerprints after every change — all identical.
3. An AST-equivalence check (docstrings stripped) confirms the executable AST is byte-identical for `data.py`, `metric.py`, `unet.py`, `util.py`. The only files with executable-token changes are `main.py` (argparse help strings only) and `model.py` (the verified dead-code removal).

## Not included (flagged for a separate PR)
- `x.contiguous()` / `x.cuda()` in `DeepLPFParameterPrediction.forward` are no-ops (return values discarded) — left as-is since "fixing" would change behaviour.
- CUDA is hard-coded at 27 sites, so the code cannot run on CPU/MPS. Making it device-agnostic is a behaviour-affecting change that warrants its own PR with GPU regression testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)