### PR TITLE
Make DeepLPF device-agnostic (CPU / Apple Silicon MPS / CUDA)

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,6 +120,15 @@ def main():
 
     logging.info('##############################')
 
+    # Select the best available device: CUDA GPU, then Apple Silicon (MPS), then CPU
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
+    logging.info('Using device: ' + str(device))
+
     BATCH_SIZE=1  # *** WARNING: batch size of > 1 not supported in current version of code ***
 
     if (checkpoint_filepath is not None) and (inference_img_dirpath is not None):
@@ -151,7 +160,8 @@ def main():
             "Performing inference with images in directory: " + inference_img_dirpath)
 
         net = model.DeepLPFNet()
-        net.load_state_dict(torch.load(checkpoint_filepath))
+        net.load_state_dict(torch.load(checkpoint_filepath, map_location=device))
+        net.to(device)
         net.eval()
 
         criterion = model.DeepLPFLoss()
@@ -189,7 +199,7 @@ def main():
                                                          shuffle=False,
                                                          num_workers=6)
         net = model.DeepLPFNet()
-        net.cuda(0)
+        net.to(device)
 
         logging.info('######### Network created #########')
         logging.info('Architecture:\n' + str(net))
@@ -228,8 +238,8 @@ def main():
             for batch_num, data in enumerate(training_data_loader, 0):
 
                 input_img_batch, gt_img_batch, _ = Variable(data['input_img'],
-                                                                       requires_grad=False).cuda(), Variable(data['output_img'],
-                                                                                                             requires_grad=False).cuda(), data[
+                                                                       requires_grad=False).to(device), Variable(data['output_img'],
+                                                                                                             requires_grad=False).to(device), data[
                     'name']
 
                 start_time = time.time()
@@ -265,8 +275,8 @@ def main():
 
                 input_img_batch, output_img_batch, category = Variable(
                     data['input_img'],
-                    requires_grad=False).cuda(), Variable(data['output_img'],
-                                                         requires_grad=False).cuda(), \
+                    requires_grad=False).to(device), Variable(data['output_img'],
+                                                         requires_grad=False).to(device), \
                     data[
                     'name']
 

--- a/metric.py
+++ b/metric.py
@@ -77,15 +77,16 @@ class Evaluator():
         if not os.path.isdir(out_dirpath):
             os.mkdir(out_dirpath)
 
-        # switch model to evaluation mode
+        # switch model to evaluation mode; run on whichever device the model
+        # already lives on (set by the caller)
         net.eval()
-        net.cuda()
+        device = next(net.parameters()).device
 
         with torch.no_grad():
             for batch_num, data in enumerate(self.data_loader, 0):
 
-                input_img_batch, output_img_batch, name = Variable(data['input_img'], requires_grad=False).cuda(), Variable(data['output_img'],
-                                                                                                   requires_grad=False).cuda(), \
+                input_img_batch, output_img_batch, name = Variable(data['input_img'], requires_grad=False).to(device), Variable(data['output_img'],
+                                                                                                   requires_grad=False).to(device), \
                     data['name']
                 input_img_batch = input_img_batch.unsqueeze(0)
 

--- a/model.py
+++ b/model.py
@@ -93,9 +93,8 @@ class DeepLPFLoss(nn.Module):
         (_, num_channel, _, _) = img1.size()
         window = self.create_window(self.ssim_window_size, num_channel)
 
-        if img1.is_cuda:
-            window = window.cuda(img1.get_device())
-            window = window.type_as(img1)
+        # Move the SSIM window to the same device and dtype as the input
+        window = window.type_as(img1)
 
         mu1 = F.conv2d(
             img1, window, padding=self.ssim_window_size // 2, groups=num_channel)
@@ -117,12 +116,12 @@ class DeepLPFLoss(nn.Module):
         C2 = 0.03 ** 2
 
         ssim_map1 = ((2 * mu1_mu2 + C1) * (2 * sigma12 + C2))
-        ssim_map2 = ((mu1_sq.cuda() + mu2_sq.cuda() + C1) *
-                     (sigma1_sq.cuda() + sigma2_sq.cuda() + C2))
-        ssim_map = ssim_map1.cuda() / ssim_map2.cuda()
+        ssim_map2 = ((mu1_sq + mu2_sq + C1) *
+                     (sigma1_sq + sigma2_sq + C2))
+        ssim_map = ssim_map1 / ssim_map2
 
-        v1 = 2.0 * sigma12.cuda() + C2
-        v2 = sigma1_sq.cuda() + sigma2_sq.cuda() + C2
+        v1 = 2.0 * sigma12 + C2
+        v2 = sigma1_sq + sigma2_sq + C2
         cs = torch.mean(v1 / v2)
 
         return ssim_map.mean(), cs
@@ -193,15 +192,14 @@ class DeepLPFLoss(nn.Module):
         num_images = target_img_batch.shape[0]
         target_img_batch = target_img_batch
 
-        ssim_loss_value = Variable(
-            torch.cuda.FloatTensor(torch.zeros(1, 1).cuda()))
-        l1_loss_value = Variable(
-            torch.cuda.FloatTensor(torch.zeros(1, 1).cuda()))
+        # Accumulate the loss on the same device/dtype as the predictions
+        ssim_loss_value = predicted_img_batch.new_zeros((1, 1))
+        l1_loss_value = predicted_img_batch.new_zeros((1, 1))
 
         for i in range(0, num_images):
 
-            target_img = target_img_batch[i, :, :, :].cuda()
-            predicted_img = predicted_img_batch[i, :, :, :].cuda()
+            target_img = target_img_batch[i, :, :, :]
+            predicted_img = predicted_img_batch[i, :, :, :]
 
             predicted_img_lab = ImageProcessing.rgb_to_lab(
                 predicted_img.squeeze(0))
@@ -322,9 +320,9 @@ class CubicFilter(nn.Module):
         cubic_mask = torch.zeros_like(img)
 
         x_axis = Variable(torch.arange(
-            img.shape[2]).view(-1, 1).repeat(1, img.shape[3]).cuda()) / img.shape[2]
+            img.shape[2]).view(-1, 1).repeat(1, img.shape[3]).to(img.device)) / img.shape[2]
         y_axis = Variable(torch.arange(img.shape[3]).repeat(
-            img.shape[2], 1).cuda()) / img.shape[3]
+            img.shape[2], 1).to(img.device)) / img.shape[3]
 
         '''
         Cubic for R channel
@@ -492,9 +490,9 @@ class GraduatedFilter(nn.Module):
         eps = 1e-10
 
         x_axis = Variable(torch.arange(
-            img.shape[2]).view(-1, 1).repeat(1, img.shape[3]).cuda()) / img.shape[2]
+            img.shape[2]).view(-1, 1).repeat(1, img.shape[3]).to(img.device)) / img.shape[2]
         y_axis = Variable(torch.arange(img.shape[3]).repeat(
-            img.shape[2], 1).cuda()) / img.shape[3]
+            img.shape[2], 1).to(img.device)) / img.shape[3]
 
         feat_graduated = torch.cat((feat, img), 1)
         feat_graduated = self.upsample(feat_graduated)
@@ -734,9 +732,9 @@ class EllipticalFilter(nn.Module):
         
         # Normalised coordinates for x and y-axes, we instantiate the ellipses in these coordinates
         x_axis = Variable(torch.arange(
-            img.shape[2]).view(-1, 1).repeat(1, img.shape[3]).cuda()) / img.shape[2]
+            img.shape[2]).view(-1, 1).repeat(1, img.shape[3]).to(img.device)) / img.shape[2]
         y_axis = Variable(torch.arange(img.shape[3]).repeat(
-            img.shape[2], 1).cuda()) / img.shape[3]
+            img.shape[2], 1).to(img.device)) / img.shape[3]
 
         # Centre of ellipse, x-coordinate
         x_coord1 = self.tanh01(G[0, 0]) + eps1
@@ -999,12 +997,12 @@ class DeepLPFParameterPrediction(nn.Module):
 
         """
         x.contiguous()  # remove memory holes
-        x.cuda()
 
         feat = x[:, 3:64, :, :]
         img = x[:, 0:3, :, :]
 
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
         img_cubic = self.cubic_filter.get_cubic_mask(feat, img)
        

--- a/util.py
+++ b/util.py
@@ -62,11 +62,11 @@ class ImageProcessing(object):
                                                     0.119193],  # G
                                                 [0.180423, 0.072169,
                                                     0.950227],  # B
-                                                ]), requires_grad=False).cuda()
+                                                ]), requires_grad=False).to(img.device)
 
         img = torch.matmul(img, rgb_to_xyz)
         img = torch.mul(img, Variable(torch.FloatTensor(
-            [1/0.950456, 1.0, 1/1.088754]), requires_grad=False).cuda())
+            [1/0.950456, 1.0, 1/1.088754]), requires_grad=False).to(img.device))
 
         epsilon = 6/29
 
@@ -76,10 +76,10 @@ class ImageProcessing(object):
         fxfyfz_to_lab = Variable(torch.FloatTensor([[0.0,  500.0,    0.0],  # fx
                                                     [116.0, -500.0,  200.0],  # fy
                                                     [0.0,    0.0, -200.0],  # fz
-                                                    ]), requires_grad=False).cuda()
+                                                    ]), requires_grad=False).to(img.device)
 
         img = torch.matmul(img, fxfyfz_to_lab) + Variable(
-            torch.FloatTensor([-16.0, 0.0, 0.0]), requires_grad=False).cuda()
+            torch.FloatTensor([-16.0, 0.0, 0.0]), requires_grad=False).to(img.device)
 
         img = img.view(shape)
         img = img.permute(2, 1, 0)


### PR DESCRIPTION
## Summary

The code hard-coded `.cuda()` at **27 sites**, so it crashed on any machine without an NVIDIA GPU — CPU-only boxes and Apple Silicon included. This replaces every hard-coded device call with a device-agnostic equivalent, so the same code now runs on **CUDA, Apple Silicon (MPS), or CPU** with no source edits.

> **Note:** this PR is **stacked on** #25 (`docs/docstrings-and-deadcode-cleanup`) to avoid `model.py` conflicts. Please merge #25 first; GitHub will then retarget this PR to `master` automatically. The diff shown here is device changes only.

## Changes
- **model.py** — SSIM window uses `.type_as(img1)`; redundant `.cuda()` calls in `compute_ssim` dropped (tensors are already on the input's device); loss accumulators use `predicted_img_batch.new_zeros(...)`; coordinate grids use `.to(img.device)`; the discarded no-op `x.cuda()` removed and `torch.cuda.empty_cache()` guarded with `torch.cuda.is_available()`.
- **util.py** — the RGB→LAB constant matrices use `.to(img.device)`.
- **metric.py** — `Evaluator.evaluate` derives the device from the model's parameters and moves inputs with `.to(device)`.
- **main.py** — selects the best available device (CUDA → MPS → CPU), moves the model and batches to it, and loads checkpoints with `map_location=device` (so a GPU-trained checkpoint loads on CPU/MPS).

## Reproducibility / verification
- A seeded forward pass, the DeepLPF loss, and `rgb_to_lab` now run **natively on CPU** (no monkeypatching) and reproduce the pre-change output tensors **bit-for-bit** (identical SHA-256). Because CPU output is unchanged and the ops are the same, **CUDA results are unchanged.**
- The forward pass and loss were confirmed to run on **Apple Silicon MPS**.
- `metric.Evaluator.evaluate` was confirmed to run **end-to-end on CPU**.

## Out of scope (noted, not changed here)
- `util.ImageProcessing.compute_ssim` passes `multichannel=True` to skimage, which newer skimage renamed to `channel_axis`. This is orthogonal to device handling and works under the repo's pinned `scikit_image==0.18.1`; worth a follow-up for newer skimage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)