### PR TITLE
Fix SSIM on modern scikit-image (multichannel -> channel_axis)

### DIFF
--- a/util.py
+++ b/util.py
@@ -19,6 +19,7 @@ Authors: Sean Moran (sean.j.moran@gmail.com),
 import matplotlib
 matplotlib.use('agg')
 from torch.autograd import Variable
+import inspect
 import numpy as np
 import torch
 import sys
@@ -26,6 +27,15 @@ from PIL import Image
 from skimage.metrics import structural_similarity as ssim
 
 np.set_printoptions(threshold=sys.maxsize)
+
+# scikit-image >= 0.19 renamed the ``multichannel=True`` argument of
+# ``structural_similarity`` to ``channel_axis``. Detect which one this
+# installation supports so the code works across skimage versions. The images
+# passed to SSIM are HxWx3, so the channel axis is the last one.
+if "channel_axis" in inspect.signature(ssim).parameters:
+    _SSIM_MULTICHANNEL_KWARGS = {"channel_axis": -1}
+else:  # older skimage (e.g. the pinned 0.18.1)
+    _SSIM_MULTICHANNEL_KWARGS = {"multichannel": True}
 
 
 class ImageProcessing(object):
@@ -208,7 +218,7 @@ class ImageProcessing(object):
                 image_batchA[i, 0:3, :, :])
             imageB = ImageProcessing.swapimdims_3HW_HW3(
                 image_batchB[i, 0:3, :, :])
-            ssim_val += ssim(imageA, imageB, data_range=imageA.max() - imageA.min(), multichannel=True,
-                             gaussian_weights=True, win_size=11)
+            ssim_val += ssim(imageA, imageB, data_range=imageA.max() - imageA.min(),
+                             gaussian_weights=True, win_size=11, **_SSIM_MULTICHANNEL_KWARGS)
 
         return ssim_val / num_images


### PR DESCRIPTION
## Summary

`ImageProcessing.compute_ssim` passes `multichannel=True` to skimage's `structural_similarity`. scikit-image **0.19 renamed** this argument to `channel_axis` and later removed the old name, so on any modern skimage the call raises:

```
ValueError: win_size exceeds image extent ... set channel_axis to the axis
number corresponding to the channels.
```

(It treats the size-3 channel axis as a 3px spatial axis, so `win_size=11` fails.) The repo's pinned `scikit_image==0.18.1` still works, but the code is broken on newer installs — which also blocks moving off the outdated pins flagged by Dependabot.

## Fix

Feature-detect the supported argument once at import via `inspect.signature`, and pass `channel_axis=-1` on skimage ≥ 0.19, falling back to `multichannel=True` on older versions. The images are HxWx3, so the channel axis is the last one; the two forms are semantically equivalent (both average SSIM across channels).

## Verification

- `metric.Evaluator.evaluate` now runs **end-to-end and computes a real SSIM on skimage 0.26** — the exact call that crashed before.
- The forward pass, loss and `rgb_to_lab` outputs are **unchanged** (bit-for-bit identical fingerprints).

> Stacked on #26 (which is stacked on #25). Suggested merge order: #25 → #26 → #27; GitHub retargets each to `master` as its base merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)