### PR TITLE
Bump dependencies to tested versions; remove bogus skimage stub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-numpy==1.22.0
-scipy==1.10.0
-torch==1.7.1
-scikit_image==0.18.1
-torchvision==0.8.2
-matplotlib==3.3.2
-imageio==2.9.0
-pillow>=8.3.2
-skimage==0.0
+numpy==2.4.6
+scipy==1.17.1
+torch==2.13.0
+scikit-image==0.26.0
+torchvision==0.28.0
+matplotlib==3.11.1
+imageio==2.37.4
+pillow==12.3.0


### PR DESCRIPTION
## Summary

The pinned dependencies dated from 2020 and no longer install cleanly on current Python/hardware. This bumps them to the versions the repo was verified against and removes a bogus line.

| Package | Old | New |
|---|---|---|
| numpy | 1.22.0 | 2.4.6 |
| scipy | 1.10.0 | 1.17.1 |
| torch | 1.7.1 | 2.13.0 |
| scikit-image | 0.18.1 | 0.26.0 |
| torchvision | 0.8.2 | 0.28.0 |
| matplotlib | 3.3.2 | 3.11.1 |
| imageio | 2.9.0 | 2.37.4 |
| pillow | >=8.3.2 | 12.3.0 |
| ~~skimage~~ | ~~0.0~~ | **removed** |

**`skimage==0.0` removed:** `skimage` on PyPI is a placeholder stub whose only job is to tell you to install `scikit-image` (already listed). The pin was useless and misleading. Also fixed the `scikit_image` → `scikit-image` spelling.

## Verification (fresh-install run-through)

A **brand-new virtualenv** installed from this `requirements.txt`:
- resolves cleanly with no conflicts;
- runs the model forward pass, DeepLPF loss, `rgb_to_lab` and `metric.Evaluator` end-to-end;
- reproduces the reference output tensors **bit-for-bit on CPU** (identical SHA-256);
- runs on **Apple Silicon (MPS)**.

## Scope note

The core inference / loss / metric paths are verified on these versions (CPU + MPS). The **full training loop** was not exercised here because it needs the Adobe5k dataset — worth a smoke run on a machine that has the data before relying on it for training.

> Best reviewed together with the device-agnostic (#26) and skimage-compat (#27) changes already on `master`, which are what make these newer versions usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)