### PR TITLE
README: fix broken result images, lower friction, make citing easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 **Huawei Noah's Ark Lab**
 
-<p>Main repository for the CVPR 2020 paper <b>DeepLPF: Deep Local Parametric Filters for Image Enhancement</b>. Here you will find a link to the code, pre-trained models and information on the datasets. Please raise a Github issue if you need assistance or have any questions on the research. 
-</p>
+Official PyTorch implementation of the CVPR 2020 paper **DeepLPF: Deep Local Parametric Filters for Image Enhancement**. DeepLPF enhances an image by regressing the parameters of a small set of spatially localised image filters — cubic, graduated and elliptical — and applying them, rather than predicting output pixels directly. On the Adobe-DPE benchmark the pre-trained model in this repository reaches **23.90 dB PSNR / 0.911 SSIM**.
 
-**_Training your own DeepLPF:_** if you have difficulties, please contact the lead author for assistance. We are responsive and will be glad to assist on any queries regarding the model.
+This repository contains the code, the pre-trained models, and instructions for preparing the datasets. If you use DeepLPF in your research, please cite [the paper](#citation) (BibTeX below). Please raise a GitHub issue if you need assistance or have any questions on the research.
+
+**_Training your own DeepLPF:_** if you have difficulties, please contact the lead author for assistance. We are happy to help with any queries regarding the model.
 
 **_BATCH SIZE: Note this code is designed for a batch size of 1. It needs to be re-engineered to support higher batch sizes. Using higher batch sizes is not supported currently. To replicate our reported results please use a batch size of 1 only. If you do have a patch for DeepLPF to support higher batch sizes please raise a pull request on this repo and we will integrate._**
 
@@ -33,9 +34,9 @@
     <th>Ours (DeepLPF)</th>
   </tr>
   <tr>
-      <td><img src="https://github.com/sjmoran/DeepLPF/blob/e6d160eed2a5f72c89e690bc81f1a59f09873085/adobe5k_dpe/deeplpf_example_test_input/a4576-DSC_0217_input.png" /></td>   
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/6889bd2c39a947ba85d86b6151387dfe56709996/adobe5k_dpe/deeplpf_example_test_output/a4576-DSC_0217_gt.png" /></td> 
-    <td><img src="https://github.com/sjmoran/DeepLPF/blob/1a76a93d5cb1fffbb8865193ba37ef83771e1f2d/adobe5k_dpe/deeplpf_example_test_inference/a4576-DSC_0217_TEST_425_9_PSNR_34.596_SSIM_0.980.jpg"/></td> 
+      <td><img src="./adobe5k_dpe/deeplpf_example_test_input/a4576-DSC_0217_input.png" /></td>   
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_output/a4576-DSC_0217_gt.png" /></td> 
+    <td><img src="./adobe5k_dpe/deeplpf_example_test_inference/a4576-DSC_0217_TEST_425_9_PSNR_34.596_SSIM_0.980.jpg"/></td> 
   </tr>
     <tr>
     <th>Input</th>
@@ -43,9 +44,9 @@
     <th>Ours (DeepLPF)</th>
   </tr>
   <tr>
-      <td><img src="https://github.com/sjmoran/DeepLPF/blob/7b6ffc8d37d26a29742c0487e94c2e00617ab149/adobe5k_dpe/deeplpf_example_test_input/a4582-DSC_0343_input.png"/></td>   
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/ff8c04db5da40e6c58f8ff42417ab57d28605d85/adobe5k_dpe/deeplpf_example_test_output/a4582-DSC_0343_gt.png"/></td> 
-    <td><img src="https://github.com/sjmoran/DeepLPF/blob/094ae4b23e0586a588960cbc31c95e09eb3f2997/adobe5k_dpe/deeplpf_example_test_inference/a4582-DSC_0343_TEST_425_10_PSNR_18.942_SSIM_0.921.jpg"/></td> 
+      <td><img src="./adobe5k_dpe/deeplpf_example_test_input/a4582-DSC_0343_input.png"/></td>   
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_output/a4582-DSC_0343_gt.png"/></td> 
+    <td><img src="./adobe5k_dpe/deeplpf_example_test_inference/a4582-DSC_0343_TEST_425_10_PSNR_18.942_SSIM_0.921.jpg"/></td> 
   </tr>
     <tr>
     <th>Input</th>
@@ -53,9 +54,9 @@
     <th>Ours (DeepLPF)</th>
   </tr>
   <tr>
-      <td><img src="https://github.com/sjmoran/DeepLPF/blob/ff2a4a6ac30a247f10c5ee2ebb96d1982725570b/adobe5k_dpe/deeplpf_example_test_input/a4742-Duggan_090331_6517_input.png"/></td>     
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/24ae58aaed19e76a59788edd04997d537bc624df/adobe5k_dpe/deeplpf_example_test_output/a4742-Duggan_090331_6517_output.png" /></td> 
-    <td><img src="https://github.com/sjmoran/DeepLPF/blob/a1f98969249067e89137b06fe82c71d44485cd4f/adobe5k_dpe/deeplpf_example_test_inference/a4742-Duggan_090331_6517_TEST_425_1_PSNR_29.825_SSIM_0.984.jpg"/></td> 
+      <td><img src="./adobe5k_dpe/deeplpf_example_test_input/a4742-Duggan_090331_6517_input.png"/></td>     
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_output/a4742-Duggan_090331_6517_output.png" /></td> 
+    <td><img src="./adobe5k_dpe/deeplpf_example_test_inference/a4742-Duggan_090331_6517_TEST_425_1_PSNR_29.825_SSIM_0.984.jpg"/></td> 
   </tr>
     <tr>
     <th>Input</th>
@@ -63,9 +64,9 @@
     <th>Ours (DeepLPF)</th>
   </tr>
   <tr>
-      <td><img src="https://github.com/sjmoran/DeepLPF/blob/3247d4dedce32aeaad54586d2c0b478189ed8d82/adobe5k_dpe/deeplpf_example_test_input/a4774-_DGW0330.png"/></td>     
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/28d9bfad7bf3649b25aa6c69dd25226474fd8339/adobe5k_dpe/deeplpf_example_test_output/a4774-_DGW0330_gt.png"/></td> 
-    <td><img src="https://github.com/sjmoran/DeepLPF/blob/37d2a682f2b0970fc0d3fd0c30d8512d909737b5/adobe5k_dpe/deeplpf_example_test_inference/a4774-_DGW0330_TEST_425_7_PSNR_24.233_SSIM_0.926.jpg"/></td> 
+      <td><img src="./adobe5k_dpe/deeplpf_example_test_input/a4774-_DGW0330.png"/></td>     
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_output/a4774-_DGW0330_gt.png"/></td> 
+    <td><img src="./adobe5k_dpe/deeplpf_example_test_inference/a4774-_DGW0330_TEST_425_7_PSNR_24.233_SSIM_0.926.jpg"/></td> 
   </tr>
     <tr>
     <th>Input</th>
@@ -73,9 +74,9 @@
     <th>Ours (DeepLPF)</th>
   </tr>
   <tr>
-      <td><img src="https://github.com/sjmoran/DeepLPF/blob/33b02f2a6f1d079e0a2b6b025f576f5b1f3c8ac7/adobe5k_dpe/deeplpf_example_test_input/a4591-Duggan_080411_5940.png" /></td>     
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/10c985c9f69cf1bb541517e14624dcdc923e2b78/adobe5k_dpe/deeplpf_example_test_output/a4591-Duggan_080411_5940.tif_GT.png"/></td> 
-    <td><img src="https://github.com/sjmoran/DeepLPF/blob/c46645adbc897ea6e773fed729b2d99d5bf59dcc/adobe5k_dpe/deeplpf_example_test_inference/a4591-Duggan_080411_5940_TEST_425_20_PSNR_28.000_SSIM_0.951.jpg"/></td> 
+      <td><img src="./adobe5k_dpe/deeplpf_example_test_input/a4591-Duggan_080411_5940.png" /></td>     
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_output/a4591-Duggan_080411_5940.tif_GT.png"/></td> 
+    <td><img src="./adobe5k_dpe/deeplpf_example_test_inference/a4591-Duggan_080411_5940_TEST_425_20_PSNR_28.000_SSIM_0.951.jpg"/></td> 
   </tr>
   <tr>
     <th>Input</th>
@@ -83,9 +84,9 @@
     <th>Ours (DeepLPF)</th>
   </tr>
   <tr>
-      <td><img src="https://github.com/sjmoran/DeepLPF/blob/b614871bb72a6573cd45fc487f5ad2d5e7e6edda/adobe5k_dpe/deeplpf_example_test_input/a4521-kme_0310.png"/></td>     
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/9404949f046a53b87a04ecc17583d0fa01951176/adobe5k_dpe/deeplpf_example_test_output/a4521-kme_0310.png"/></td> 
-    <td><img src="https://github.com/sjmoran/DeepLPF/blob/7b5e10962cead0b0c20e47f7a0c750562f7bfc74/adobe5k_dpe/deeplpf_example_test_inference/a4521-kme_0310_TEST_800_5_PSNR_28.774_SSIM_0.897.jpg"/></td> 
+      <td><img src="./adobe5k_dpe/deeplpf_example_test_input/a4521-kme_0310.png"/></td>     
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_output/a4521-kme_0310.png"/></td> 
+    <td><img src="./adobe5k_dpe/deeplpf_example_test_inference/a4521-kme_0310_TEST_800_5_PSNR_28.774_SSIM_0.897.jpg"/></td> 
   </tr>
   <tr>
     <th>Input</th>
@@ -93,9 +94,9 @@
     <th>Ours (DeepLPF)</th>
   </tr>
   <tr>
-    <td><img src="https://github.com/sjmoran/DeepLPF/blob/76bbc1d5673cf0c90c7316d93fecefa9b5a62052/adobe5k_dpe/deeplpf_example_test_input/a4869-09-05-19-at-19h05m38s-_MG_9563.png"/></td>     
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/62d12eff53e30382553f75c32743596a7919deba/adobe5k_dpe/deeplpf_example_test_output/a4869-09-05-19-at-19h05m38s-_MG_9563.png"/></td>     
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/c75cea3d600136005ea1078db3fc663011c54d8b/adobe5k_dpe/deeplpf_example_test_inference/a4869-09-05-19-at-19h05m38s-_MG_9563_TEST_500_29_PSNR_30.090_SSIM_0.978.jpg"/></td> 
+    <td><img src="./adobe5k_dpe/deeplpf_example_test_input/a4869-09-05-19-at-19h05m38s-_MG_9563.png"/></td>     
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_output/a4869-09-05-19-at-19h05m38s-_MG_9563.png"/></td>     
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_inference/a4869-09-05-19-at-19h05m38s-_MG_9563_TEST_500_29_PSNR_30.090_SSIM_0.978.jpg"/></td> 
   </tr>
   <tr>
     <th>Input</th> 
@@ -103,8 +104,8 @@
     <th>Ours (DeepLPF)</th>
   </tr>
   <tr>
-    <td><img src="https://github.com/sjmoran/DeepLPF/blob/c50fa517cbeb88ace1970b54da712e7872fbd95f/adobe5k_dpe/deeplpf_example_test_input/a4933-Duggan_090428_8040.png" /></td>   
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/86a9b78ff36d3f71d491a158fd7956b5880cd991/adobe5k_dpe/deeplpf_example_test_output/a4933-Duggan_090428_8040.png"/></td>     <td><img src="https://github.com/sjmoran/DeepLPF/blob/7745ebfb35fc9a6c8e27bbc09c4b82c94a77e632/adobe5k_dpe/deeplpf_example_test_inference/a4933-Duggan_090428_8040_TEST_500_23_PSNR_19.011_SSIM_0.882.jpg"/></td> 
+    <td><img src="./adobe5k_dpe/deeplpf_example_test_input/a4933-Duggan_090428_8040.png" /></td>   
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_output/a4933-Duggan_090428_8040.png"/></td>     <td><img src="./adobe5k_dpe/deeplpf_example_test_inference/a4933-Duggan_090428_8040_TEST_500_23_PSNR_19.011_SSIM_0.882.jpg"/></td> 
   </tr>
      <tr>
     <th>Input</th> 
@@ -112,9 +113,9 @@
     <th>Ours (DeepLPF)</th>
   </tr>
   <tr>
-    <td><img src="https://github.com/sjmoran/DeepLPF/blob/944e9bfac7ecf7b20b53f1142bf57bf0d2c6bfaf/adobe5k_dpe/deeplpf_example_test_input/a4783-20090321_at_19h16m32__MG_0220.png"/></td>   
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/4b5448fc529f9f5f71d117ad6fb54215ae2164c8/adobe5k_dpe/deeplpf_example_test_output/a4783-20090321_at_19h16m32__MG_0220.png"/></td>     
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/f8b20f0a102c549f716748a3d5e353c48a24d768/adobe5k_dpe/deeplpf_example_test_inference/a4783-20090321_at_19h16m32__MG_0220_TEST_500_2_PSNR_26.362_SSIM_0.905.jpg"/></td> 
+    <td><img src="./adobe5k_dpe/deeplpf_example_test_input/a4783-20090321_at_19h16m32__MG_0220.png"/></td>   
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_output/a4783-20090321_at_19h16m32__MG_0220.png"/></td>     
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_inference/a4783-20090321_at_19h16m32__MG_0220_TEST_500_2_PSNR_26.362_SSIM_0.905.jpg"/></td> 
   </tr>
         <tr>
     <th>Input</th> 
@@ -122,15 +123,17 @@
     <th>Ours (DeepLPF)</th>
   </tr>
   <tr>
-    <td><img src="https://github.com/sjmoran/DeepLPF/blob/fc339bc7177aad138cdd7b3378056b97e6b5afc9/adobe5k_dpe/deeplpf_example_test_input/a4514-kme_0258.png"/></td>   
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/2e2213fbdf07f890e22c40ef2ee31c7cafe98679/adobe5k_dpe/deeplpf_example_test_output/a4514-kme_0258.png"/></td>     
-     <td><img src="https://github.com/sjmoran/DeepLPF/blob/2e2213fbdf07f890e22c40ef2ee31c7cafe98679/adobe5k_dpe/deeplpf_example_test_inference/a4514-kme_0258_TEST_500_27_PSNR_27.426_SSIM_0.879.jpg"/></td> 
+    <td><img src="./adobe5k_dpe/deeplpf_example_test_input/a4514-kme_0258.png"/></td>   
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_output/a4514-kme_0258.png"/></td>     
+     <td><img src="./adobe5k_dpe/deeplpf_example_test_inference/a4514-kme_0258_TEST_500_27_PSNR_27.426_SSIM_0.879.jpg"/></td> 
   </tr>
 </table>
 
 ### Dependencies
 
-_requirements.txt_ contains the Python packages used by the code.
+_requirements.txt_ lists the Python packages used by the code; install them with `pip install -r requirements.txt`.
+
+The code selects the best available device automatically and runs on a CUDA GPU, Apple Silicon (MPS), or CPU.
 
 ### How to train DeepLPF and use the model for inference
 
@@ -174,7 +177,9 @@ python3 main.py --inference_img_list_path=./adobe5k_dpe/images_inference.txt --i
 * Adobe-DPE: see pretrained_models/adobe_dpe directory. Model trained on the Adobe5K dataset using the splits and image pre-processing outlined in the DeepPhotoEnhancer paper.
 * Adobe-UPE: see pretrained_models/adobe_upe directory. Model trained on the Adobe5K dataset using the splits and image pre-processing outlined in the DeepUPE paper. Thanks to Yucheng Lu (yucheng.l@outlook.com) for this pre-trained model. The model was applied in [this paper](https://arxiv.org/abs/2106.14844).
 
-### Bibtex
+### Citation
+
+If you use DeepLPF, its pre-trained models, or this code in your research, please cite:
 
 ```
 @InProceedings{Moran_2020_CVPR,
@@ -188,7 +193,7 @@ year = {2020}
 
 ### Datasets
 
-* __Adobe-DPE__ (5000 images, RGB, RGB pairs): this dataset can be downloaded [here](https://data.csail.mit.edu/graphics/fivek/). After downloading this dataset you will need to use Lightroom to pre-process the images according to the procedure outlined in the DeepPhotoEnhancer (DPE) [paper](https://github.com/nothinglo/Deep-Photo-Enhancer). Please see the issue [here](https://github.com/nothinglo/Deep-Photo-Enhancer/issues/38#issuecomment-449786636) for instructions. Artist C retouching is used as the groundtruth/target. Note, the images must be extracted in sRGB space. Feel free to raise a Gitlab issue if you need assistance with this (or indeed the Adobe-UPE dataset below). You can also find the training, validation and testing dataset splits for Adobe-DPE in the following [file](https://www.cmlab.csie.ntu.edu.tw/project/Deep-Photo-Enhancer/%5BExperimental_Code_Data%5D_Deep-Photo-Enhancer.zip). The splits can also be found the the [adobe5k_dpe](./adobe5k_dpe/) directory in this repository (note these are a best guess at what the orginal splits from the DPE authors might be).
+* __Adobe-DPE__ (5000 images, RGB, RGB pairs): this dataset can be downloaded [here](https://data.csail.mit.edu/graphics/fivek/). After downloading this dataset you will need to use Lightroom to pre-process the images according to the procedure outlined in the DeepPhotoEnhancer (DPE) [paper](https://github.com/nothinglo/Deep-Photo-Enhancer). Please see the issue [here](https://github.com/nothinglo/Deep-Photo-Enhancer/issues/38#issuecomment-449786636) for instructions. Artist C retouching is used as the groundtruth/target. Note, the images must be extracted in sRGB space. Feel free to raise a GitHub issue if you need assistance with this (or indeed the Adobe-UPE dataset below). You can also find the training, validation and testing dataset splits for Adobe-DPE in the following [file](https://www.cmlab.csie.ntu.edu.tw/project/Deep-Photo-Enhancer/%5BExperimental_Code_Data%5D_Deep-Photo-Enhancer.zip). The splits can also be found in the [adobe5k_dpe](./adobe5k_dpe/) directory in this repository (note these are a best guess at what the original splits from the DPE authors might be).
 
 * __Adobe-UPE__ (5000 images, RGB, RGB pairs): this dataset can be downloaded [here](https://data.csail.mit.edu/graphics/fivek/). As above, you will need to use Lightroom to pre-process the images according to the procedure outlined in the Underexposed Photo Enhancement Using Deep Illumination Estimation (DeepUPE) [paper](https://github.com/wangruixing/DeepUPE) and detailed in the issue [here](https://github.com/wangruixing/DeepUPE/issues/26). Artist C retouching is used as the groundtruth/target. You can find the test images for the Adobe-UPE dataset at this [link](https://drive.google.com/file/d/1HZnNgptNxjKJAhekz2K5yh0mW0yKIws2/view?usp=sharing).
 
@@ -205,5 +210,5 @@ If you plan to contribute new features, utility functions or extensions to the c
 ### Errata for Paper(s) referencing DeepLPF
 
 * **[Deep Symmetric Network for Underexposed Image Enhancement with Recurrent Attentional Learning](https://www.shaopinglu.net/publications_files/ICCV21_Image_Enhancement.pdf)**
-* The results in Fig 1. for DeepLPF in this paper are incorrect. An example of inference for one of the images in Fig 1. is supplied [here](https://github.com/sjmoran/DeepLPF/blob/ecdc6f08cc96ff727a8246874bce06726949068e/images/004668_TEST_25_354_PSNR_21.848_SSIM_0.858.jpg). For replication, we provide our DeepLPF pre-trained model for their dataset [here](https://github.com/sjmoran/DeepLPF/blob/7b147dd819b2e4c8e9898c411f23887250cb9afe/pretrained_models/adobe_distort_and_recover/deeplpf_validpsnr_23.629675866286313_validloss_0.030986817553639412_testpsnr_23.629675866286313_testloss_0.030986817553639412_epoch_49_model.pt). The quantitative results in Table 1 for DeepLPF should be: **23.63dB, 0.875 SSIM**. 
+* The results in Fig 1. for DeepLPF in this paper are incorrect. An example of inference for one of the images in Fig 1. is supplied [here](./images/004668_TEST_25_354_PSNR_21.848_SSIM_0.858.jpg). For replication, we provide our DeepLPF pre-trained model for their dataset [here](./pretrained_models/adobe_distort_and_recover/deeplpf_validpsnr_23.629675866286313_validloss_0.030986817553639412_testpsnr_23.629675866286313_testloss_0.030986817553639412_epoch_49_model.pt). The quantitative results in Table 1 for DeepLPF should be: **23.63dB, 0.875 SSIM**. 
 * **29th September 2021**: The paper authors have graciously noted this issue and have created an errata to their ICCV paper [here](https://www.shaopinglu.net/proj-iccv21/ImageEnhancement.html). We thank the authors and appreciate their time commitment and close collaboration in re-checking the DeepLPF result in their paper.


### PR DESCRIPTION
## Summary

A README cleanup aimed at making the repo easier to understand, run, and cite.

## Changes

- **Fixed the results table (the biggest issue).** The example images pointed at `github.com/sjmoran/DeepLPF/blob/<sha>/…` URLs. A `/blob/` link renders GitHub's HTML file viewer, not the raw image, so the input/label/output comparison grid was showing broken images. All 30 now use **relative paths** to the copies already in this repo (`./adobe5k_dpe/…`), verified to exist — so they render on the repo page and can't break from a rename.
- **Headline up top.** Added a one-line description of what DeepLPF does and the headline Adobe-DPE result (**23.90 dB PSNR / 0.911 SSIM**) so a visitor sees the method and result immediately.
- **Easier to cite.** Renamed the `Bibtex` section to **`Citation`** with a short "please cite" lead-in, and linked to it from the intro. The BibTeX entry itself is **byte-for-byte unchanged**.
- **Lower friction to run.** Noted that the code now runs on CUDA / Apple Silicon (MPS) / CPU (per the device-agnostic change already on `master`), and added the `pip install -r requirements.txt` line.
- **Typos:** `Gitlab issue` → `GitHub issue`, `orginal` → `original`, `found the the` → `found in the`.

## Notes

- Verified all 30 referenced images exist locally before switching to relative paths.
- Ran the house prose checks: no hype/marketing constructions, em-dash density 2 per ~1,200 words, headings stay descriptive, and every claim (the result number, device support) is checkable. The canonical CVPR BibTeX is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)