### PR TITLE
Add CI: smoke tests + checkpoint faithfulness guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies (CPU)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run smoke and faithfulness tests
+        run: pytest -q

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Make the repo modules (model, data, util, ...) importable from the test suite.
+ROOT = os.path.dirname(os.path.abspath(__file__))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -1,0 +1,77 @@
+"""Faithfulness check: the shipped adobe_dpe checkpoint still reproduces the
+paper-era results on the bundled example images.
+
+The example inference filenames encode the PSNR/SSIM the epoch-424 model
+produced in 2020 (the ``TEST_425`` tag == epoch 424). This test runs that same
+checkpoint through the repo's inference pipeline on those five images and
+asserts the PSNR still matches.
+
+Tolerance is deliberately generous. On the reference platform four of the five
+images reproduce PSNR to three decimals; a4774 sits near a BinaryLayer
+above/below-line decision and drifts ~0.8 dB across torch versions. The test
+guards against real regressions (a broken filter shifts PSNR by many dB), not
+against last-digit numerical noise, and stays robust across platforms.
+"""
+import glob
+import os
+import re
+
+import torch
+
+import model
+import metric
+from data import Adobe5kDataLoader, Dataset
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Reference PSNR/SSIM parsed from the shipped TEST_425 (epoch-424) filenames.
+REFERENCE = {
+    "a4576": 34.596,
+    "a4582": 18.942,
+    "a4591": 28.000,
+    "a4742": 29.825,
+    "a4774": 24.233,
+}
+PSNR_TOL_DB = 2.0
+
+
+def test_pretrained_checkpoint_reproduces_reference(tmp_path):
+    ckpts = glob.glob(os.path.join(ROOT, "pretrained_models", "adobe_dpe", "*.pt"))
+    assert ckpts, "adobe_dpe checkpoint not found"
+
+    id_list = tmp_path / "ids.txt"
+    id_list.write_text("\n".join(REFERENCE) + "\n")
+
+    net = model.DeepLPFNet()
+    net.load_state_dict(torch.load(ckpts[0], map_location="cpu"))
+    net.to("cpu").eval()
+
+    loader = Adobe5kDataLoader(
+        data_dirpath=os.path.join(ROOT, "adobe5k_dpe") + "/",
+        img_ids_filepath=str(id_list),
+    )
+    data_dict = loader.load_data()
+    dataset = Dataset(data_dict=data_dict, normaliser=1, is_inference=True)
+    dl = torch.utils.data.DataLoader(dataset, batch_size=1, shuffle=False, num_workers=0)
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    metric.Evaluator(model.DeepLPFLoss(), dl, "test", str(out_dir)).evaluate(net, epoch=0)
+
+    produced = {}
+    for fn in glob.glob(str(out_dir / "test" / "*.jpg")):
+        base = os.path.basename(fn)
+        iid = base.split("-")[0]
+        m = re.search(r"PSNR_([0-9]+\.[0-9]+)", base)
+        if m:
+            produced[iid] = float(m.group(1))
+
+    missing = set(REFERENCE) - set(produced)
+    assert not missing, "no output produced for %s" % sorted(missing)
+
+    for iid, ref_psnr in REFERENCE.items():
+        delta = abs(produced[iid] - ref_psnr)
+        assert delta <= PSNR_TOL_DB, (
+            "%s: PSNR %.3f dB drifted %.3f dB from reference %.3f dB (tol %.1f dB)"
+            % (iid, produced[iid], delta, ref_psnr, PSNR_TOL_DB)
+        )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,50 @@
+"""Fast smoke tests: the model builds and runs, and the metric path works.
+
+These need no data or checkpoint. The metric test exercises PSNR (numpy) and
+SSIM (scikit-image) end-to-end, which is the path a scikit-image API change
+would break.
+"""
+import torch
+
+import model
+import metric
+
+
+def test_forward_pass_cpu():
+    torch.manual_seed(0)
+    net = model.DeepLPFNet().eval()
+    x = torch.rand(1, 3, 64, 64)
+    with torch.no_grad():
+        y = net(x)
+    assert tuple(y.shape) == (1, 3, 64, 64)
+    assert torch.isfinite(y).all()
+    assert (y >= 0).all() and (y <= 1).all()  # output is clamped to [0, 1]
+
+
+def test_loss_cpu():
+    torch.manual_seed(0)
+    loss_fn = model.DeepLPFLoss()
+    a = torch.rand(1, 3, 64, 64)
+    b = torch.rand(1, 3, 64, 64)
+    with torch.no_grad():
+        loss = loss_fn(a, b)
+    assert torch.isfinite(loss).all()
+    assert float(loss) >= 0.0
+
+
+def test_metric_evaluator_cpu(tmp_path):
+    torch.manual_seed(0)
+    net = model.DeepLPFNet()
+    crit = model.DeepLPFLoss()
+    # Mimic a torch DataLoader (batch dim already present) with two tiny samples.
+    loader = [
+        {
+            "input_img": torch.rand(1, 3, 48, 48),
+            "output_img": torch.rand(1, 3, 48, 48),
+            "name": ["sample_%d.png" % k],
+        }
+        for k in range(2)
+    ]
+    loss, psnr, ssim = metric.Evaluator(crit, loader, "test", str(tmp_path)).evaluate(net, epoch=0)
+    assert psnr > 0.0
+    assert 0.0 <= ssim <= 1.0

--- a/util.py
+++ b/util.py
@@ -144,11 +144,17 @@ class ImageProcessing(object):
         """Loads an image from file as a numpy multi-dimensional array
 
         :param img_filepath: filepath to the image
+        :param normaliser: value to divide the pixel intensities by (e.g. 255)
         :returns: image as a multi-dimensional numpy array
         :rtype: multi-dimensional numpy array
 
         """
-        img = ImageProcessing.normalise_image(np.array(Image.open(img_filepath)), normaliser)  # NB: imread normalises to 0-1
+        img = np.array(Image.open(img_filepath))
+        if img.ndim == 3 and img.shape[2] == 4:
+            # Drop an alpha channel if present (RGBA -> RGB); the network is
+            # trained on 3-channel RGB input.
+            img = img[:, :, :3]
+        img = ImageProcessing.normalise_image(img, normaliser)  # NB: imread normalises to 0-1
 
         return img
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that installs the pinned `requirements.txt` on CPU and runs a pytest suite on every push and PR. This is the durable version of the ad-hoc regression harness used across the recent PRs — it catches dependency breaks (like the scikit-image `multichannel` removal) and numerical regressions automatically.

## Tests

**`tests/test_smoke.py`** — no data or checkpoint required:
- `test_forward_pass_cpu` — model builds, forward runs, output is finite and clamped to [0, 1].
- `test_loss_cpu` — the DeepLPF loss computes a finite non-negative value.
- `test_metric_evaluator_cpu` — `metric.Evaluator` runs end-to-end on synthetic data, exercising the PSNR (numpy) and **SSIM (scikit-image)** path. This is the path a scikit-image API change would break.

**`tests/test_replication.py`** — faithfulness guard:
- Loads the shipped `adobe_dpe` epoch-424 checkpoint and runs it through the repo's own inference pipeline on the five bundled `TEST_425` example images, asserting the PSNR still matches the values baked into their filenames (produced by the same checkpoint in 2020 on torch 1.7.1).
- On the reference platform, four of five reproduce PSNR to three decimals; a4774 drifts ~0.8 dB near a `BinaryLayer` above/below-line decision. Tolerance is a generous **2 dB** so the test catches real regressions (a broken filter shifts PSNR by many dB) while staying robust across platforms and torch versions.

## Small fix folded in

`ImageProcessing.load_image` now drops an alpha channel when present (RGBA → RGB). The bundled example PNGs carry an alpha channel, which otherwise crashes the documented inference command (the network expects 3 channels). The change is a no-op for RGB inputs and leaves the forward/loss/`rgb_to_lab` outputs unchanged (golden fingerprints identical); it also makes the README's inference example run out-of-the-box.

## Verified locally

`pytest -q` → **4 passed in ~3s**, run in a fresh virtualenv installed from `requirements.txt` (the same steps CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)