### PR TITLE
Add --crop_size so batch>1 training works on variable-size FiveK images

### DIFF
--- a/data.py
+++ b/data.py
@@ -41,11 +41,16 @@ class Dataset(torch.utils.data.Dataset):
     modes load the images unaugmented.
     """
 
-    def __init__(self, data_dict, transform=None, normaliser=2 ** 8 - 1, is_valid=False, is_inference=False):
+    def __init__(self, data_dict, transform=None, normaliser=2 ** 8 - 1, is_valid=False, is_inference=False, crop_size=None):
         """Initialisation for the Dataset object
 
         :param data_dict: dictionary of dictionaries containing images
         :param transform: PyTorch image transformations to apply to the images
+        :param crop_size: if set, training images are randomly cropped to this
+            square size (the same crop is applied to input and target). Needed
+            for a batch size greater than one, since FiveK images vary in size
+            and the default collation requires a uniform size. Ignored for
+            validation and inference.
         :returns: N/A
         :rtype: N/A
 
@@ -55,6 +60,7 @@ class Dataset(torch.utils.data.Dataset):
         self.normaliser = normaliser
         self.is_valid = is_valid
         self.is_inference = is_inference
+        self.crop_size = crop_size
 
     def __len__(self):
         """Returns the number of images in the dataset
@@ -123,6 +129,17 @@ class Dataset(torch.utils.data.Dataset):
                         if random.random() > 0.5:
                             input_img = TF.vflip(input_img)
                             output_img = TF.vflip(output_img)
+
+                    # Random square crop (same crop for input and target) so
+                    # that a batch size > 1 can collate variable-size images.
+                    if self.crop_size:
+                        width, height = input_img.size
+                        crop = min(self.crop_size, width, height)
+                        left = random.randint(0, width - crop)
+                        top = random.randint(0, height - crop)
+                        box = (left, top, left + crop, top + crop)
+                        input_img = input_img.crop(box)
+                        output_img = output_img.crop(box)
 
                 # Transform to tensor
                 input_img = TF.to_tensor(input_img)

--- a/docs/ADOBE_DPE_DATASET.md
+++ b/docs/ADOBE_DPE_DATASET.md
@@ -16,7 +16,9 @@ benchmark; use the steps below if you want faithfulness to the paper.
 - The **MIT-Adobe FiveK** dataset (~50 GB of raw DNG files plus a Lightroom
   catalogue): <https://data.csail.mit.edu/graphics/fivek/>
 - **Adobe Lightroom Classic** (the catalogue `fivek.lrcat` opens in Lightroom).
-- Disk space for the exported PNGs (a few GB at 512px).
+- **Disk space:** the FiveK archive is ~47 GiB and extracts to a similar size, so
+  plan for **~95 GiB free** for the raw dataset (an external drive is fine), plus
+  a few GB for the exported 512px PNGs.
 
 The raw download and the Lightroom export are manual steps — Lightroom is a GUI
 application and cannot be scripted here. The scripts in `data_prep/` handle
@@ -114,6 +116,22 @@ python main.py \
   --test_img_list_path=./adobe5k_dpe/images_test.txt \
   --batch_size=1
 ```
+
+**Batch size > 1** needs a uniform image size, because FiveK images vary in
+dimensions and the default collation cannot stack different-sized tensors. Pass
+`--crop_size` to randomly crop training pairs to a fixed square, e.g. for a batch
+of 8 with 256×256 crops:
+
+```bash
+python main.py \
+  --training_img_dirpath=./adobe5k_dpe_data/ \
+  --train_img_list_path=./adobe5k_dpe/images_train.txt \
+  --valid_img_list_path=./adobe5k_dpe/images_valid.txt \
+  --test_img_list_path=./adobe5k_dpe/images_test.txt \
+  --batch_size=8 --crop_size=256
+```
+
+Evaluation and inference run at batch size 1 and are not cropped.
 
 Run inference with a pretrained checkpoint:
 

--- a/main.py
+++ b/main.py
@@ -77,6 +77,10 @@ def main():
     parser.add_argument(
         "--batch_size", type=int, required=False, help="Training batch size (default 1)", default=1)
     parser.add_argument(
+        "--crop_size", type=int, required=False, default=0,
+        help="If >0, randomly crop training images to this square size. Required "
+             "for --batch_size>1 because FiveK images vary in size.")
+    parser.add_argument(
         "--valid_every", type=int, required=False, help="Number of epochs after which to compute validation accuracy",
         default=25)
     parser.add_argument(
@@ -103,6 +107,7 @@ def main():
     args = parser.parse_args()
     num_epoch = args.num_epoch
     batch_size = args.batch_size
+    crop_size = args.crop_size
     valid_every = args.valid_every
     checkpoint_filepath = args.checkpoint_filepath
     inference_img_dirpath = args.inference_img_dirpath
@@ -183,7 +188,13 @@ def main():
                                                  img_ids_filepath=train_img_list_path)
         training_data_dict = training_data_loader.load_data()
 
-        training_dataset = Dataset(data_dict=training_data_dict, normaliser=1, is_valid=False)
+        if BATCH_SIZE > 1 and crop_size <= 0:
+            logging.warning(
+                "batch_size > 1 requires uniform image sizes; FiveK images vary. "
+                "Pass --crop_size (e.g. --crop_size 256) or the data loader will "
+                "fail to collate. Continuing anyway.")
+        training_dataset = Dataset(data_dict=training_data_dict, normaliser=1, is_valid=False,
+                                   crop_size=(crop_size if crop_size > 0 else None))
 
         validation_data_loader = Adobe5kDataLoader(data_dirpath=training_img_dirpath,
                                                img_ids_filepath=valid_img_list_path)

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -1,0 +1,50 @@
+"""A batch size > 1 needs uniform image sizes; --crop_size provides them.
+
+FiveK images vary in size, so the default DataLoader collation fails for
+batch>1. Dataset(crop_size=N) random-crops training pairs to NxN so batches
+collate. This test builds a tiny dataset from the bundled (variable-size)
+example images and checks that crop_size yields uniform NxN batches.
+"""
+import glob
+import os
+
+import torch
+
+from data import Adobe5kDataLoader, Dataset
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+EX = os.path.join(ROOT, "adobe5k_dpe")
+
+
+def _tiny_dataset(tmp_path, crop_size):
+    in_dir = os.path.join(EX, "deeplpf_example_test_input")
+    out_dir = os.path.join(EX, "deeplpf_example_test_output")
+    ins = {os.path.basename(f).split("-")[0] for f in glob.glob(in_dir + "/*.png")}
+    outs = {os.path.basename(f).split("-")[0] for f in glob.glob(out_dir + "/*.png")}
+    ids = sorted(ins & outs)
+    id_file = tmp_path / "ids.txt"
+    id_file.write_text("\n".join(ids) + "\n")
+    data_dict = Adobe5kDataLoader(data_dirpath=EX + "/", img_ids_filepath=str(id_file)).load_data()
+    return Dataset(data_dict=data_dict, normaliser=255, is_valid=False, crop_size=crop_size), len(ids)
+
+
+def test_crop_size_gives_uniform_batches(tmp_path):
+    ds, n = _tiny_dataset(tmp_path, crop_size=256)
+    assert n >= 3
+    dl = torch.utils.data.DataLoader(ds, batch_size=3, shuffle=False, num_workers=0)
+    batch = next(iter(dl))
+    assert tuple(batch["input_img"].shape) == (3, 3, 256, 256)
+    assert tuple(batch["output_img"].shape) == (3, 3, 256, 256)
+
+
+def test_without_crop_mixed_sizes_do_not_collate(tmp_path):
+    # The bundled examples are mixed-size (512x341 and 512x343); batch>1 without
+    # a crop must fail to collate, which is exactly why --crop_size exists.
+    ds, _ = _tiny_dataset(tmp_path, crop_size=None)
+    dl = torch.utils.data.DataLoader(ds, batch_size=3, shuffle=False, num_workers=0)
+    try:
+        next(iter(dl))
+        raised = False
+    except RuntimeError:
+        raised = True
+    assert raised, "expected mixed-size batch>1 to fail collation without crop_size"


### PR DESCRIPTION
## Summary

Batch>1 was supported by the model (#31) but not actually usable on real data. FiveK images vary in size, and the default `DataLoader` collation can't stack different-sized tensors, so `--batch_size>1` crashed on real data. This adds an optional random crop so batches have a uniform size.

## Changes

- **`Dataset(crop_size=N)`** applies the same random N×N crop to each input/target **training** pair (after the existing flips). Validation and inference are untouched. Default `None` keeps the current behaviour exactly — the batch-size-1 path is unchanged.
- **`main.py`** gains `--crop_size` and warns if `--batch_size>1` is passed without it.
- **`docs/ADOBE_DPE_DATASET.md`**: documents the batch>1 + `--crop_size` workflow, and adds the ~95 GiB disk requirement for the raw FiveK (download + extraction).

## Why this was needed

Found while running an end-to-end training smoke on real image files: mixed-size batches fail to collate. So the batch>1 feature, as merged, only worked on synthetic same-size tensors. `--crop_size` makes it usable on FiveK.

## Verified

- End-to-end on the bundled (variable-size) example images: a full train → loss → backward → `metric.Evaluator` → checkpoint save/reload loop runs at `--batch_size 2`.
- `tests/test_crop.py`: `crop_size=256` yields uniform `(3,3,256,256)` batches; without it, mixed-size batch>1 fails to collate (the exact failure `--crop_size` fixes).
- Full suite: 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)